### PR TITLE
ADH-4803

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -129,8 +129,12 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
     // Use common defaults file, if not specified by user
     propertiesFile = Option(propertiesFile).getOrElse(Utils.getDefaultPropertiesFile(env))
     // Honor --conf before the defaults file
+    // Filter sparkProperties to exclude blacklisted properties using default options
+    val filteredProp = Utils.filterBlacklistedProperties(defaultSparkProperties, sparkProperties)
+
+    // Merge filtered default properties into sparkProperties
     defaultSparkProperties.foreach { case (k, v) =>
-      if (!sparkProperties.contains(k)) {
+      if (!filteredProp.contains(k)) {
         sparkProperties(k) = v
       }
     }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2554,4 +2554,12 @@ package object config {
       .stringConf
       .toSequence
       .createWithDefault("org.apache.spark.sql.connect.client" :: Nil)
+
+  private[spark] val SPARK_SQL_CONF_BLACKLIST =
+    ConfigBuilder("spark.sql.security.confblacklist")
+      .internal()
+      .version("3.5.1")
+      .stringConf
+      .toSequence
+      .createOptional
 }

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -122,6 +122,29 @@ private[spark] object Utils
   private val copyBuffer = ThreadLocal.withInitial[Array[Byte]](() => {
     new Array[Byte](COPY_BUFFER_LEN)
   })
+
+  /**
+   * Filters out blacklisted properties from the given configuration options.
+   *
+   * @param defaultOptions The default configuration options containing the blacklist key.
+   * @param options The original configuration options to be filtered.
+   * @return A filtered map excluding blacklisted properties.
+   */
+  def filterBlacklistedProperties(defaultOptions: Map[String, String],
+                                  options: Map[String, String]): Map[String, String] = {
+    // Extract blacklisted properties, defaulting to an empty string if not present
+    val blackListedProperties = defaultOptions
+      .getOrElse(SPARK_SQL_CONF_BLACKLIST.key, "")
+      .split(",")
+      .toSet
+
+    // Ensure the blacklist contains the SPARK_SQL_CONF_BLACKLIST.key itself
+    val completeBlacklist = blackListedProperties + SPARK_SQL_CONF_BLACKLIST.key
+
+    // Filter options to exclude blacklisted properties
+    options.filterNot { case (k, _) => completeBlacklist.contains(k) }
+  }
+
   /** Deserialize a Long value (used for [[org.apache.spark.api.python.PythonPartitioner]]) */
   def deserializeLongValue(bytes: Array[Byte]) : Long = {
     // Note: we assume that we are given a Long value encoded in network (big-endian) byte order

--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.apache.spark.launcher.CommandBuilderUtils.*;
 
@@ -266,8 +267,12 @@ abstract class AbstractCommandBuilder {
     if (effectiveConfig == null) {
       effectiveConfig = new HashMap<>(conf);
       Properties p = loadPropertiesFile();
-      p.stringPropertyNames().forEach(key ->
-        effectiveConfig.computeIfAbsent(key, p::getProperty));
+      Set<String> propertyBlackList =
+              Arrays.stream(p.getProperty(SPARK_SQL_CONF_BLACKLIST, "").split(","))
+                      .collect(Collectors.toSet());
+      p.stringPropertyNames().stream()
+              .filter(key -> !propertyBlackList.contains(key))
+              .forEach(key -> effectiveConfig.computeIfAbsent(key, p::getProperty));
     }
     return effectiveConfig;
   }

--- a/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
@@ -30,6 +30,7 @@ class CommandBuilderUtils {
   static final String DEFAULT_MEM = "1g";
   static final String DEFAULT_PROPERTIES_FILE = "spark-defaults.conf";
   static final String ENV_SPARK_HOME = "SPARK_HOME";
+  static final String SPARK_SQL_CONF_BLACKLIST = "spark.sql.security.confblacklist";
 
   /** Returns whether the given string is null or empty. */
   static boolean isEmpty(String s) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -1067,7 +1067,14 @@ object SparkSession extends Logging {
      */
     def getOrCreate(): SparkSession = synchronized {
       val sparkConf = new SparkConf()
-      options.foreach { case (k, v) => sparkConf.set(k, v) }
+
+      // Filter options to exclude blacklisted properties
+      val filteredOptions = Utils.filterBlacklistedProperties(sparkConf.getAll.toMap, options)
+
+      // Set filtered configuration options in sparkConf
+      filteredOptions.foreach { case (k, v) =>
+        sparkConf.set(k, v)
+      }
 
       if (!sparkConf.get(EXECUTOR_ALLOW_SPARK_CONTEXT)) {
         assertOnDriver()


### PR DESCRIPTION
ADH-4803: Add blacklist filter to exclude certain properties

- Introduced a blacklist feature to filter out specific properties from being added to the effective configuration map.
- The blacklist is defined by the 'SPARK_SQL_CONF_BLACKLIST' property, which contains a comma-separated list of keys to exclude.

This enhancement allows for more granular control over which configuration properties are included, preventing unwanted overrides.