### PR TITLE
fix(table): Fix handling of external.table.purge property for external tables

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -4448,7 +4448,7 @@
   },
   "_LEGACY_ERROR_TEMP_1266" : {
     "message" : [
-      "Operation not allowed: TRUNCATE TABLE on external tables: <tableIdentWithDB>."
+      "Operation not allowed: TRUNCATE TABLE on external tables without 'external.table.purge' set to true: <tableIdentWithDB>."
     ]
   },
   "_LEGACY_ERROR_TEMP_1267" : {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -460,8 +460,13 @@ case class TruncateTableCommand(
     val catalog = spark.sessionState.catalog
     val table = catalog.getTableMetadata(tableName)
     val tableIdentWithDB = table.identifier.quotedString
+    val purgeOption: Option[String] = table.properties.get("external.table.purge")
+    val purge: Boolean = purgeOption match {
+      case Some(value) => value.toBoolean
+      case None => false
+    }
 
-    if (table.tableType == CatalogTableType.EXTERNAL) {
+    if (table.tableType == CatalogTableType.EXTERNAL && !purge) {
       throw QueryCompilationErrors.truncateTableOnExternalTablesError(tableIdentWithDB)
     }
     if (table.partitionColumnNames.isEmpty && partitionSpec.isDefined) {


### PR DESCRIPTION
fix(table): Fix handling of external.table.purge property for external tables
fix(table): Fix error message _LEGACY_ERROR_TEMP_1266