### PR TITLE
NGSOK-1131: Skip files that spark-submit cannon process to ConfigMap

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStep.scala
@@ -18,8 +18,10 @@ package org.apache.spark.deploy.k8s.features
 
 import java.io.File
 import java.nio.charset.StandardCharsets
+import java.nio.charset.MalformedInputException
 
 import scala.collection.JavaConverters._
+import scala.io.{Codec, Source}
 
 import com.google.common.io.Files
 import io.fabric8.kubernetes.api.model._
@@ -27,13 +29,14 @@ import io.fabric8.kubernetes.api.model._
 import org.apache.spark.deploy.k8s.{KubernetesConf, KubernetesUtils, SparkPod}
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
+import org.apache.spark.internal.Logging
 
 /**
  * Mounts the Hadoop configuration - either a pre-defined config map, or a local configuration
  * directory - on the driver pod.
  */
 private[spark] class HadoopConfDriverFeatureStep(conf: KubernetesConf)
-  extends KubernetesFeatureConfigStep {
+  extends KubernetesFeatureConfigStep with Logging {
 
   private val confDir = Option(conf.sparkConf.getenv(ENV_HADOOP_CONF_DIR))
   private val existingConfMap = conf.get(KUBERNETES_HADOOP_CONF_CONFIG_MAP)
@@ -44,10 +47,26 @@ private[spark] class HadoopConfDriverFeatureStep(conf: KubernetesConf)
     "Do not specify both the `HADOOP_CONF_DIR` in your ENV and the ConfigMap " +
     "as the creation of an additional ConfigMap, when one is already specified is extraneous")
 
+  private def isText(file: File): Boolean = {
+    var source: Source = Source.fromString("") // init with empty source.
+    try {
+      source = Source.fromFile(file)(Codec.UTF8)
+      val fileContent = source.mkString
+      true
+    } catch {
+      case e: MalformedInputException =>
+        logWarning(
+          s"Unable to read a non UTF-8 encoded file ${file.getAbsolutePath}. Skipping...", e)
+        false
+    } finally {
+      source.close()
+    }
+  }
+
   private lazy val confFiles: Seq[File] = {
     val dir = new File(confDir.get)
     if (dir.isDirectory) {
-      dir.listFiles.filter(_.isFile).toSeq
+      dir.listFiles.filter(_.isFile).filter(_.canRead).filter(isText(_)).toSeq
     } else {
       Nil
     }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
@@ -166,7 +166,7 @@ private[spark] object KubernetesClientUtils extends Logging {
       f.getName.matches("spark.*(conf|properties)")
 
     val fileFilter = (f: File) => {
-      f.isFile && !testIfTooLargeOrBinary(f) && !testIfSparkConfOrTemplates(f)
+      f.isFile && f.canRead && !testIfTooLargeOrBinary(f) && !testIfSparkConfOrTemplates(f)
     }
     val confFiles: Seq[File] = {
       val dir = new File(confDir)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStepSuite.scala
@@ -17,6 +17,8 @@
 package org.apache.spark.deploy.k8s.features
 
 import java.io.File
+import java.io._
+import scala.util.Using
 import java.nio.charset.StandardCharsets.UTF_8
 
 import scala.collection.JavaConverters._
@@ -50,6 +52,22 @@ class HadoopConfDriverFeatureStepSuite extends SparkFunSuite {
     confFiles.foreach { f =>
       Files.write("some data", new File(confDir, f), UTF_8)
     }
+
+    val numbers = List(10, 200, 3000, 40000)
+    val binaryFile = new File(confDir, "another.bin").getAbsolutePath()
+
+    Using(new DataOutputStream(new BufferedOutputStream(new FileOutputStream(binaryFile)))) {
+      dos =>
+        numbers.foreach(dos.writeInt)
+    }.recover {
+      case e: IOException => e.printStackTrace()
+    }
+
+    val nonReadableFile = new File(confDir, "non-readable.xml")
+
+    Files.write("some data", nonReadableFile, UTF_8)
+
+    nonReadableFile.setReadable(false)
 
     val sparkConf = new SparkConfWithEnv(Map(ENV_HADOOP_CONF_DIR -> confDir.getAbsolutePath()))
     val conf = KubernetesTestConf.createDriverConf(sparkConf = sparkConf)


### PR DESCRIPTION
We may have files which are binary or not-readable in config dirs, let's skip them when run spark-submit to k8s

### What changes were proposed in this pull request?
We may have files which are binary or not-readable in config dirs, let's skip them when run spark-submit to k8s


### Why are the changes needed?
To avoid errors reading configs


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manually


### Was this patch authored or co-authored using generative AI tooling?
No
