### PR TITLE
NGSOK-1130: Forcefully exit driver Pod to avoid hung in Running state

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -1023,10 +1023,13 @@ private[spark] class SparkSubmit extends Logging {
         e
     }
 
+    var exitCode: Int = 0
+
     try {
       app.start(childArgs.toArray, sparkConf)
     } catch {
       case t: Throwable =>
+        exitCode = 1
         throw findCause(t)
     } finally {
       if (args.master.startsWith("k8s") && !isShell(args.primaryResource) &&
@@ -1035,8 +1038,11 @@ private[spark] class SparkSubmit extends Logging {
         try {
           SparkContext.getActive.foreach(_.stop())
         } catch {
-          case e: Throwable => logError("Failed to close SparkContext", e)
+          case e: Throwable =>
+            exitCode = 1
+            logError("Failed to close SparkContext", e)
         }
+        sys.exit(exitCode)
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In case of ranger audit enabled with Ozone+Zookeeper we have non-daemon thread with `zkConnectionManagerCallback` prefix which do not allow Pod to stop. Let's explicitly run `sys.exit` to invoke shutdown hooks and exit pod with exit code based on error existence.


### Why are the changes needed?
To be able to stop driver k8s Pod with non-daemon threads.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manually, with k8s master in cluster mode with Ozone+Zookeeper enabled. Tested exit code in case of wrong app as well.


### Was this patch authored or co-authored using generative AI tooling?
No