### PR TITLE
NGSOK-1387: Use binaryData to populate binary files

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
@@ -104,7 +104,8 @@ private[spark] class BasicExecutorFeatureStep(
     val configMapName = KubernetesClientUtils.configMapNameExecutor
     val confFilesMap = KubernetesClientUtils
       .buildSparkConfDirFilesMap(configMapName, kubernetesConf.sparkConf, Map.empty)
-    val keyToPaths = KubernetesClientUtils.buildKeyToPathObjects(confFilesMap)
+    val keyToPaths = KubernetesClientUtils.buildKeyToPathObjects(confFilesMap, true)
+    val keyToPathsBinary = KubernetesClientUtils.buildKeyToPathObjects(confFilesMap, false)
     // According to
     // https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names,
     // hostname must be no longer than `KUBERNETES_DNS_LABEL_NAME_MAX_LENGTH`(63) characters,
@@ -278,7 +279,7 @@ private[spark] class BasicExecutorFeatureStep(
         .addNewVolume()
           .withName(SPARK_CONF_VOLUME_EXEC)
           .withNewConfigMap()
-            .withItems(keyToPaths.asJava)
+            .withItems((keyToPaths ++ keyToPathsBinary).asJava)
             .withName(configMapName)
             .endConfigMap()
           .endVolume()

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStep.scala
@@ -17,8 +17,8 @@
 package org.apache.spark.deploy.k8s.features
 
 import java.io.File
-import java.nio.charset.StandardCharsets
 import java.nio.charset.MalformedInputException
+import java.nio.charset.StandardCharsets
 
 import scala.collection.JavaConverters._
 import scala.io.{Codec, Source}

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStep.scala
@@ -25,6 +25,7 @@ import scala.io.{Codec, Source}
 
 import com.google.common.io.Files
 import io.fabric8.kubernetes.api.model._
+import org.apache.commons.codec.binary.Base64
 
 import org.apache.spark.deploy.k8s.{KubernetesConf, KubernetesUtils, SparkPod}
 import org.apache.spark.deploy.k8s.Config._
@@ -66,7 +67,7 @@ private[spark] class HadoopConfDriverFeatureStep(conf: KubernetesConf)
   private lazy val confFiles: Seq[File] = {
     val dir = new File(confDir.get)
     if (dir.isDirectory) {
-      dir.listFiles.filter(_.isFile).filter(_.canRead).filter(isText(_)).toSeq
+      dir.listFiles.filter(_.isFile).filter(_.canRead).toSeq
     } else {
       Nil
     }
@@ -133,8 +134,11 @@ private[spark] class HadoopConfDriverFeatureStep(conf: KubernetesConf)
 
   override def getAdditionalKubernetesResources(): Seq[HasMetadata] = {
     if (confDir.isDefined) {
-      val fileMap = confFiles.map { file =>
+      val fileMap = confFiles.filter(isText(_)).map { file =>
         (file.getName(), Files.toString(file, StandardCharsets.UTF_8))
+      }.toMap.asJava
+      val fileBinaryMap = confFiles.filterNot(isText(_)).map { file =>
+        (file.getName(), Base64.encodeBase64String(Files.toByteArray(file)))
       }.toMap.asJava
 
       Seq(new ConfigMapBuilder()
@@ -143,6 +147,7 @@ private[spark] class HadoopConfDriverFeatureStep(conf: KubernetesConf)
           .endMetadata()
         .withImmutable(true)
         .addToData(fileMap)
+        .addToBinaryData(fileBinaryMap)
         .build())
     } else {
       Nil

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
@@ -106,7 +106,7 @@ private[spark] class Client(
     val confFilesMap = KubernetesClientUtils.buildSparkConfDirFilesMap(configMapName,
       conf.sparkConf, resolvedDriverSpec.systemProperties)
     val configMap = KubernetesClientUtils.buildConfigMap(configMapName, confFilesMap +
-        (KUBERNETES_NAMESPACE.key -> conf.namespace))
+        (KUBERNETES_NAMESPACE.key -> (conf.namespace, true)))
 
     // The include of the ENV_VAR for "SPARK_CONF_DIR" is to allow for the
     // Spark command builder to pickup on the Java Options present in the ConfigMap
@@ -126,7 +126,7 @@ private[spark] class Client(
         .addNewVolume()
           .withName(SPARK_CONF_VOLUME_DRIVER)
           .withNewConfigMap()
-            .withItems(KubernetesClientUtils.buildKeyToPathObjects(confFilesMap).asJava)
+            .withItems((KubernetesClientUtils.buildKeyToPathObjects(confFilesMap, true)++KubernetesClientUtils.buildKeyToPathObjects(confFilesMap, false)).asJava)
             .withName(configMapName)
             .endConfigMap()
           .endVolume()

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
@@ -126,7 +126,9 @@ private[spark] class Client(
         .addNewVolume()
           .withName(SPARK_CONF_VOLUME_DRIVER)
           .withNewConfigMap()
-            .withItems((KubernetesClientUtils.buildKeyToPathObjects(confFilesMap, true)++KubernetesClientUtils.buildKeyToPathObjects(confFilesMap, false)).asJava)
+            .withItems((KubernetesClientUtils.buildKeyToPathObjects(confFilesMap, true)
+              ++KubernetesClientUtils.buildKeyToPathObjects(confFilesMap, false))
+              .sortBy(x => x.getKey).asJava)
             .withName(configMapName)
             .endConfigMap()
           .endVolume()
@@ -152,6 +154,9 @@ private[spark] class Client(
       createdDriverPod =
         kubernetesClient.pods().inNamespace(conf.namespace).resource(resolvedDriverPod).create()
     } catch {
+      case e: NullPointerException =>
+        println(confFilesMap)
+        throw e
       case NonFatal(e) =>
         kubernetesClient.resourceList(preKubernetesResources: _*).delete()
         logError("Please check \"kubectl auth can-i create pod\" first. It should be yes.")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
@@ -106,7 +106,7 @@ private[spark] class Client(
     val confFilesMap = KubernetesClientUtils.buildSparkConfDirFilesMap(configMapName,
       conf.sparkConf, resolvedDriverSpec.systemProperties)
     val configMap = KubernetesClientUtils.buildConfigMap(configMapName, confFilesMap +
-        (KUBERNETES_NAMESPACE.key -> (conf.namespace, true)))
+        (KUBERNETES_NAMESPACE.key -> ConfigMapItem(conf.namespace, true)))
 
     // The include of the ENV_VAR for "SPARK_CONF_DIR" is to allow for the
     // Spark command builder to pickup on the Java Options present in the ConfigMap
@@ -127,7 +127,7 @@ private[spark] class Client(
           .withName(SPARK_CONF_VOLUME_DRIVER)
           .withNewConfigMap()
             .withItems((KubernetesClientUtils.buildKeyToPathObjects(confFilesMap, true)
-              ++KubernetesClientUtils.buildKeyToPathObjects(confFilesMap, false))
+              ++ KubernetesClientUtils.buildKeyToPathObjects(confFilesMap, false))
               .sortBy(x => x.getKey).asJava)
             .withName(configMapName)
             .endConfigMap()
@@ -154,9 +154,6 @@ private[spark] class Client(
       createdDriverPod =
         kubernetesClient.pods().inNamespace(conf.namespace).resource(resolvedDriverPod).create()
     } catch {
-      case e: NullPointerException =>
-        println(confFilesMap)
-        throw e
       case NonFatal(e) =>
         kubernetesClient.resourceList(preKubernetesResources: _*).delete()
         logError("Please check \"kubectl auth can-i create pod\" first. It should be yes.")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
@@ -79,7 +79,9 @@ private[spark] object KubernetesClientUtils extends Logging {
     }
   }
 
-  def buildKeyToPathObjects(confFilesMap: Map[String, ConfigMapItem], isPlainText: Boolean): Seq[KeyToPath] = {
+  def buildKeyToPathObjects(
+                             confFilesMap: Map[String, ConfigMapItem],
+                             isPlainText: Boolean): Seq[KeyToPath] = {
     confFilesMap.filter(a => a._2._2 == isPlainText).map {
       case (fileName: String, (_, _)) =>
         val filePermissionMode = 420  // 420 is decimal for octal literal 0644.
@@ -94,7 +96,8 @@ private[spark] object KubernetesClientUtils extends Logging {
   def buildConfigMap(configMapName: String, confFileMap: Map[String, (String, Boolean)],
       withLabels: Map[String, String] = Map()): ConfigMap = {
     val configMapNameSpace =
-      confFileMap.getOrElse(KUBERNETES_NAMESPACE.key, (KUBERNETES_NAMESPACE.defaultValueString, true))
+      confFileMap.getOrElse(KUBERNETES_NAMESPACE.key,
+        (KUBERNETES_NAMESPACE.defaultValueString, true))
     new ConfigMapBuilder()
       .withNewMetadata()
         .withName(configMapName)
@@ -138,8 +141,10 @@ private[spark] object KubernetesClientUtils extends Logging {
         } catch {
           case e: MalformedInputException =>
             logWarning(
-              s"Unable to read a non UTF-8 encoded file ${file.getAbsolutePath}. Adding as binary...", e)
-            val (fileName, fileContent) = file.getName -> Base64.encodeBase64String(Files.toByteArray(file))
+              s"Unable to read a non UTF-8 encoded file ${file.getAbsolutePath}. " +
+                s"Adding as binary...", e)
+            val (fileName, fileContent) = file.getName ->
+              Base64.encodeBase64String(Files.toByteArray(file))
             if ((truncatedMapSize + fileName.length + fileContent.length) < maxSize) {
               truncatedMap.put(fileName, (fileContent, false))
               truncatedMapSize = truncatedMapSize + (fileName.length + fileContent.length)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
@@ -35,9 +35,9 @@ import org.apache.spark.deploy.k8s.Config.{KUBERNETES_DNS_SUBDOMAIN_NAME_MAX_LEN
 import org.apache.spark.deploy.k8s.Constants.ENV_SPARK_CONF_DIR
 import org.apache.spark.internal.Logging
 
-private[spark] object KubernetesClientUtils extends Logging {
+case class ConfigMapItem(path: String, isPlainText: Boolean)
 
-  type ConfigMapItem = (String, Boolean)
+private[spark] object KubernetesClientUtils extends Logging {
 
   // Config map name can be KUBERNETES_DNS_SUBDOMAIN_NAME_MAX_LENGTH chars at max.
   def configMapName(prefix: String): String = {
@@ -73,7 +73,8 @@ private[spark] object KubernetesClientUtils extends Logging {
     if (resolvedPropertiesMap.nonEmpty) {
       val resolvedProperties: String = KubernetesClientUtils
         .buildStringFromPropertiesMap(configMapName, resolvedPropertiesMap)
-      loadedConfFilesMap ++ Map(Constants.SPARK_CONF_FILE_NAME -> (resolvedProperties, true))
+      loadedConfFilesMap ++ Map(Constants.SPARK_CONF_FILE_NAME ->
+        ConfigMapItem(resolvedProperties, true))
     } else {
       loadedConfFilesMap
     }
@@ -82,8 +83,8 @@ private[spark] object KubernetesClientUtils extends Logging {
   def buildKeyToPathObjects(
                              confFilesMap: Map[String, ConfigMapItem],
                              isPlainText: Boolean): Seq[KeyToPath] = {
-    confFilesMap.filter(a => a._2._2 == isPlainText).map {
-      case (fileName: String, (_, _)) =>
+    confFilesMap.filter(a => a._2.isPlainText == isPlainText).map {
+      case (fileName: String, _) =>
         val filePermissionMode = 420  // 420 is decimal for octal literal 0644.
         new KeyToPath(fileName, filePermissionMode, fileName)
     }.toList.sortBy(x => x.getKey) // List is sorted to make mocking based tests work
@@ -93,20 +94,22 @@ private[spark] object KubernetesClientUtils extends Logging {
    * Build a Config Map that will hold the content for environment variable SPARK_CONF_DIR
    * on remote pods.
    */
-  def buildConfigMap(configMapName: String, confFileMap: Map[String, (String, Boolean)],
+  def buildConfigMap(configMapName: String, confFileMap: Map[String, ConfigMapItem],
       withLabels: Map[String, String] = Map()): ConfigMap = {
     val configMapNameSpace =
       confFileMap.getOrElse(KUBERNETES_NAMESPACE.key,
-        (KUBERNETES_NAMESPACE.defaultValueString, true))
+        ConfigMapItem(KUBERNETES_NAMESPACE.defaultValueString, true))
     new ConfigMapBuilder()
       .withNewMetadata()
         .withName(configMapName)
-        .withNamespace(configMapNameSpace._1)
+        .withNamespace(configMapNameSpace.path)
         .withLabels(withLabels.asJava)
         .endMetadata()
       .withImmutable(true)
-      .addToData(confFileMap.collect{case (key, (value, true)) => key -> value}.asJava)
-      .addToBinaryData(confFileMap.collect{case (key, (value, false)) => key -> value}.asJava)
+      .addToData(confFileMap.collect{case (key, ConfigMapItem(value, true)) => key -> value}.asJava)
+      .addToBinaryData(confFileMap.collect {
+        case (key, ConfigMapItem(value, false)) => key -> value
+      }.asJava)
       .build()
   }
 
@@ -133,7 +136,7 @@ private[spark] object KubernetesClientUtils extends Logging {
           source = Source.fromFile(file)(Codec.UTF8)
           val (fileName, fileContent) = file.getName -> source.mkString
           if ((truncatedMapSize + fileName.length + fileContent.length) < maxSize) {
-            truncatedMap.put(fileName, (fileContent, true))
+            truncatedMap.put(fileName, ConfigMapItem(fileContent, true))
             truncatedMapSize = truncatedMapSize + (fileName.length + fileContent.length)
           } else {
             skippedFiles.add(fileName)
@@ -146,7 +149,7 @@ private[spark] object KubernetesClientUtils extends Logging {
             val (fileName, fileContent) = file.getName ->
               Base64.encodeBase64String(Files.toByteArray(file))
             if ((truncatedMapSize + fileName.length + fileContent.length) < maxSize) {
-              truncatedMap.put(fileName, (fileContent, false))
+              truncatedMap.put(fileName, ConfigMapItem(fileContent, false))
               truncatedMapSize = truncatedMapSize + (fileName.length + fileContent.length)
             } else {
               skippedFiles.add(fileName)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
@@ -25,7 +25,9 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.io.{Codec, Source}
 
+import com.google.common.io.Files
 import io.fabric8.kubernetes.api.model.{ConfigMap, ConfigMapBuilder, KeyToPath}
+import org.apache.commons.codec.binary.Base64
 
 import org.apache.spark.SparkConf
 import org.apache.spark.deploy.k8s.{Config, Constants, KubernetesUtils}
@@ -34,6 +36,8 @@ import org.apache.spark.deploy.k8s.Constants.ENV_SPARK_CONF_DIR
 import org.apache.spark.internal.Logging
 
 private[spark] object KubernetesClientUtils extends Logging {
+
+  type ConfigMapItem = (String, Boolean)
 
   // Config map name can be KUBERNETES_DNS_SUBDOMAIN_NAME_MAX_LENGTH chars at max.
   def configMapName(prefix: String): String = {
@@ -63,21 +67,21 @@ private[spark] object KubernetesClientUtils extends Logging {
   def buildSparkConfDirFilesMap(
       configMapName: String,
       sparkConf: SparkConf,
-      resolvedPropertiesMap: Map[String, String]): Map[String, String] = synchronized {
+      resolvedPropertiesMap: Map[String, String]): Map[String, ConfigMapItem] = synchronized {
     val loadedConfFilesMap = KubernetesClientUtils.loadSparkConfDirFiles(sparkConf)
     // Add resolved spark conf to the loaded configuration files map.
     if (resolvedPropertiesMap.nonEmpty) {
       val resolvedProperties: String = KubernetesClientUtils
         .buildStringFromPropertiesMap(configMapName, resolvedPropertiesMap)
-      loadedConfFilesMap ++ Map(Constants.SPARK_CONF_FILE_NAME -> resolvedProperties)
+      loadedConfFilesMap ++ Map(Constants.SPARK_CONF_FILE_NAME -> (resolvedProperties, true))
     } else {
       loadedConfFilesMap
     }
   }
 
-  def buildKeyToPathObjects(confFilesMap: Map[String, String]): Seq[KeyToPath] = {
-    confFilesMap.map {
-      case (fileName: String, _: String) =>
+  def buildKeyToPathObjects(confFilesMap: Map[String, ConfigMapItem], isPlainText: Boolean): Seq[KeyToPath] = {
+    confFilesMap.filter(a => a._2._2 == isPlainText).map {
+      case (fileName: String, (_, _)) =>
         val filePermissionMode = 420  // 420 is decimal for octal literal 0644.
         new KeyToPath(fileName, filePermissionMode, fileName)
     }.toList.sortBy(x => x.getKey) // List is sorted to make mocking based tests work
@@ -87,18 +91,19 @@ private[spark] object KubernetesClientUtils extends Logging {
    * Build a Config Map that will hold the content for environment variable SPARK_CONF_DIR
    * on remote pods.
    */
-  def buildConfigMap(configMapName: String, confFileMap: Map[String, String],
+  def buildConfigMap(configMapName: String, confFileMap: Map[String, (String, Boolean)],
       withLabels: Map[String, String] = Map()): ConfigMap = {
     val configMapNameSpace =
-      confFileMap.getOrElse(KUBERNETES_NAMESPACE.key, KUBERNETES_NAMESPACE.defaultValueString)
+      confFileMap.getOrElse(KUBERNETES_NAMESPACE.key, (KUBERNETES_NAMESPACE.defaultValueString, true))
     new ConfigMapBuilder()
       .withNewMetadata()
         .withName(configMapName)
-        .withNamespace(configMapNameSpace)
+        .withNamespace(configMapNameSpace._1)
         .withLabels(withLabels.asJava)
         .endMetadata()
       .withImmutable(true)
-      .addToData(confFileMap.asJava)
+      .addToData(confFileMap.collect{case (key, (value, true)) => key -> value}.asJava)
+      .addToBinaryData(confFileMap.collect{case (key, (value, false)) => key -> value}.asJava)
       .build()
   }
 
@@ -109,7 +114,7 @@ private[spark] object KubernetesClientUtils extends Logging {
   }
 
   // exposed for testing
-  private[submit] def loadSparkConfDirFiles(conf: SparkConf): Map[String, String] = {
+  private[submit] def loadSparkConfDirFiles(conf: SparkConf): Map[String, ConfigMapItem] = {
     val confDir = Option(conf.getenv(ENV_SPARK_CONF_DIR)).orElse(
       conf.getOption("spark.home").map(dir => s"$dir/conf"))
     val maxSize = conf.get(Config.CONFIG_MAP_MAXSIZE)
@@ -117,7 +122,7 @@ private[spark] object KubernetesClientUtils extends Logging {
       val confFiles: Seq[File] = listConfFiles(confDir.get, maxSize)
       val orderedConfFiles = orderFilesBySize(confFiles)
       var truncatedMapSize: Long = 0
-      val truncatedMap = mutable.HashMap[String, String]()
+      val truncatedMap = mutable.HashMap[String, ConfigMapItem]()
       val skippedFiles = mutable.HashSet[String]()
       var source: Source = Source.fromString("") // init with empty source.
       for (file <- orderedConfFiles) {
@@ -125,7 +130,7 @@ private[spark] object KubernetesClientUtils extends Logging {
           source = Source.fromFile(file)(Codec.UTF8)
           val (fileName, fileContent) = file.getName -> source.mkString
           if ((truncatedMapSize + fileName.length + fileContent.length) < maxSize) {
-            truncatedMap.put(fileName, fileContent)
+            truncatedMap.put(fileName, (fileContent, true))
             truncatedMapSize = truncatedMapSize + (fileName.length + fileContent.length)
           } else {
             skippedFiles.add(fileName)
@@ -133,8 +138,14 @@ private[spark] object KubernetesClientUtils extends Logging {
         } catch {
           case e: MalformedInputException =>
             logWarning(
-              s"Unable to read a non UTF-8 encoded file ${file.getAbsolutePath}. Skipping...", e)
-            None
+              s"Unable to read a non UTF-8 encoded file ${file.getAbsolutePath}. Adding as binary...", e)
+            val (fileName, fileContent) = file.getName -> Base64.encodeBase64String(Files.toByteArray(file))
+            if ((truncatedMapSize + fileName.length + fileContent.length) < maxSize) {
+              truncatedMap.put(fileName, (fileContent, false))
+              truncatedMapSize = truncatedMapSize + (fileName.length + fileContent.length)
+            } else {
+              skippedFiles.add(fileName)
+            }
         } finally {
           source.close()
         }
@@ -149,7 +160,7 @@ private[spark] object KubernetesClientUtils extends Logging {
       }
       truncatedMap.toMap
     } else {
-      Map.empty[String, String]
+      Map.empty[String, ConfigMapItem]
     }
   }
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
@@ -78,11 +78,9 @@ private[spark] class KubernetesClusterSchedulerBackend(
 
   private def setUpExecutorConfigMap(driverPod: Option[Pod]): Unit = {
     val configMapName = KubernetesClientUtils.configMapNameExecutor
-    val resolvedExecutorProperties =
-      Map(KUBERNETES_NAMESPACE.key -> namespace)
     val confFilesMap = KubernetesClientUtils
-      .buildSparkConfDirFilesMap(configMapName, conf, resolvedExecutorProperties) ++
-      resolvedExecutorProperties
+      .buildSparkConfDirFilesMap(configMapName, conf, Map(KUBERNETES_NAMESPACE.key -> namespace)) ++
+      Map(KUBERNETES_NAMESPACE.key -> (namespace, true))
     val labels =
       Map(SPARK_APP_ID_LABEL -> applicationId(), SPARK_ROLE_LABEL -> SPARK_POD_EXECUTOR_ROLE)
     val configMap = KubernetesClientUtils.buildConfigMap(configMapName, confFilesMap, labels)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
@@ -30,7 +30,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.deploy.k8s.{KubernetesConf, KubernetesUtils}
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
-import org.apache.spark.deploy.k8s.submit.KubernetesClientUtils
+import org.apache.spark.deploy.k8s.submit.{ConfigMapItem, KubernetesClientUtils}
 import org.apache.spark.deploy.security.HadoopDelegationTokenManager
 import org.apache.spark.internal.config.SCHEDULER_MIN_REGISTERED_RESOURCES_RATIO
 import org.apache.spark.resource.ResourceProfile
@@ -80,7 +80,7 @@ private[spark] class KubernetesClusterSchedulerBackend(
     val configMapName = KubernetesClientUtils.configMapNameExecutor
     val confFilesMap = KubernetesClientUtils
       .buildSparkConfDirFilesMap(configMapName, conf, Map(KUBERNETES_NAMESPACE.key -> namespace)) ++
-      Map(KUBERNETES_NAMESPACE.key -> (namespace, true))
+      Map(KUBERNETES_NAMESPACE.key -> ConfigMapItem(namespace, true))
     val labels =
       Map(SPARK_APP_ID_LABEL -> applicationId(), SPARK_ROLE_LABEL -> SPARK_POD_EXECUTOR_ROLE)
     val configMap = KubernetesClientUtils.buildConfigMap(configMapName, confFilesMap, labels)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStepSuite.scala
@@ -16,12 +16,12 @@
  */
 package org.apache.spark.deploy.k8s.features
 
-import java.io.File
 import java.io._
-import scala.util.Using
+import java.io.File
 import java.nio.charset.StandardCharsets.UTF_8
 
 import scala.collection.JavaConverters._
+import scala.util.Using
 
 import com.google.common.io.Files
 import io.fabric8.kubernetes.api.model.ConfigMap

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStepSuite.scala
@@ -77,6 +77,7 @@ class HadoopConfDriverFeatureStepSuite extends SparkFunSuite {
 
     val hadoopConfMap = filter[ConfigMap](step.getAdditionalKubernetesResources()).head
     assert(hadoopConfMap.getData().keySet().asScala === confFiles)
+    assert(hadoopConfMap.getBinaryData().keySet().asScala === Set("another.bin"))
   }
 
   private def checkPod(pod: SparkPod): Unit = {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/ClientSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/ClientSuite.scala
@@ -274,8 +274,11 @@ class ClientSuite extends SparkFunSuite with BeforeAndAfter {
   }
 
   test("All files from SPARK_CONF_DIR, " +
-    "except templates, spark config, binary files and are within size limit, " +
+    "except templates, spark config and are within size limit, " +
     "should be populated to pod's configMap.") {
+
+    val nonUTFFileName = "non_utf8.txt"
+
     def testSetup: (SparkConf, Seq[String]) = {
       val tempDir = Utils.createTempDir()
       val sparkConf = new SparkConf(loadDefaults = false)
@@ -286,13 +289,13 @@ class ClientSuite extends SparkFunSuite with BeforeAndAfter {
       // File names - which should not get mounted on the resultant config map.
       val filteredConfFileNames =
         Set("spark-env.sh.template", "spark.properties", "spark-defaults.conf",
-          "test.gz", "test2.jar", "non_utf8.txt")
+          "test.gz", "test2.jar")
       val confFileNames = (for (i <- 1 to 5) yield s"testConf.$i") ++
-        List("spark-env.sh") ++ filteredConfFileNames
+        List("spark-env.sh", nonUTFFileName) ++ filteredConfFileNames
 
       val testConfFiles = (for (i <- confFileNames) yield {
         val file = new File(s"${tempConfDir.getAbsolutePath}/$i")
-        if (i.startsWith("non_utf8")) { // filling some non-utf-8 binary
+        if (i.startsWith(nonUTFFileName)) { // filling some non-utf-8 binary
           Files.write(file.toPath, Array[Byte](0x00.toByte, 0xA1.toByte))
         } else {
           Files.write(file.toPath, "conf1key=conf1value".getBytes(StandardCharsets.UTF_8))
@@ -334,11 +337,15 @@ class ClientSuite extends SparkFunSuite with BeforeAndAfter {
     val configMapName = KubernetesClientUtils.configMapNameDriver
     val configMap: ConfigMap = configMaps.head
     assert(configMap.getMetadata.getName == configMapName)
-    val configMapLoadedFiles = configMap.getData.keySet().asScala.toSet -
-        Config.KUBERNETES_NAMESPACE.key
+    val configMapLoadedFiles = configMap.getData.keySet().asScala.toSet + nonUTFFileName -
+      Config.KUBERNETES_NAMESPACE.key
     assert(configMapLoadedFiles === expectedConfFiles.toSet ++ Set(SPARK_CONF_FILE_NAME))
     for (f <- configMapLoadedFiles) {
-      assert(configMap.getData.get(f).contains("conf1key=conf1value"))
+      if (f != nonUTFFileName) {
+        assert(configMap.getData.get(f).contains("conf1key=conf1value"))
+      } else {
+        assert(configMap.getBinaryData.containsKey(f))
+      }
     }
   }
 

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtilsSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtilsSuite.scala
@@ -25,6 +25,7 @@ import java.util.UUID
 import scala.collection.JavaConverters._
 
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder
+import org.apache.commons.codec.binary.Base64
 import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
@@ -49,13 +50,16 @@ class KubernetesClientUtilsSuite extends SparkFunSuite with BeforeAndAfter {
   }
 
   test("verify load files, loads only allowed files and not the disallowed files.") {
+    val data = Array[Byte](0x00.toByte, 0xA1.toByte)
     val input: Map[String, Array[Byte]] = Map("test.txt" -> "test123", "z12.zip" -> "zZ",
       "rere.jar" -> "@31", "spark.jar" -> "@31", "_test" -> "", "sample.conf" -> "conf")
       .map(f => f._1 -> f._2.getBytes(StandardCharsets.UTF_8)) ++
-      Map("binary-file.conf" -> Array[Byte](0x00.toByte, 0xA1.toByte))
+      Map("binary-file.conf" -> data)
     val sparkConf = testSetup(input)
     val output = KubernetesClientUtils.loadSparkConfDirFiles(sparkConf)
-    val expectedOutput = Map("test.txt" -> "test123", "sample.conf" -> "conf", "_test" -> "")
+    val expectedOutput = Map("test.txt" -> ("test123", true),
+      "sample.conf" -> ("conf", true), "_test" -> ("", true),
+      "binary-file.conf" -> (Base64.encodeBase64String(data), false))
     assert(output === expectedOutput)
   }
 
@@ -64,11 +68,12 @@ class KubernetesClientUtilsSuite extends SparkFunSuite with BeforeAndAfter {
     val sparkConf = testSetup(input.map(f => f._1 -> f._2.getBytes(StandardCharsets.UTF_8)))
       .set(Config.CONFIG_MAP_MAXSIZE.key, "60")
     val output = KubernetesClientUtils.loadSparkConfDirFiles(sparkConf)
-    val expectedOutput = Map("testConf.1" -> "test123456", "testConf.2" -> "test123456")
+    val expectedOutput = Map("testConf.1" -> ("test123456", true),
+      "testConf.2" -> ("test123456", true))
     assert(output === expectedOutput)
     val output1 = KubernetesClientUtils.loadSparkConfDirFiles(
       sparkConf.set(Config.CONFIG_MAP_MAXSIZE.key, "250000"))
-    assert(output1 === input)
+    assert(output1 === input.map(a => a._1 -> (a._2, true)))
   }
 
   test("verify load files, truncates the content to maxSize, when keys are equal in length.") {
@@ -76,8 +81,9 @@ class KubernetesClientUtilsSuite extends SparkFunSuite with BeforeAndAfter {
     val sparkConf = testSetup(input.map(f => f._1 -> f._2.getBytes(StandardCharsets.UTF_8)))
       .set(Config.CONFIG_MAP_MAXSIZE.key, "80")
     val output = KubernetesClientUtils.loadSparkConfDirFiles(sparkConf)
-    val expectedOutput = Map("testConf.1" -> "test123456", "testConf.2" -> "test123456",
-      "testConf.3" -> "test123456")
+    val expectedOutput = Map("testConf.1" -> ("test123456", true),
+      "testConf.2" -> ("test123456", true),
+      "testConf.3" -> ("test123456", true))
     assert(output === expectedOutput)
   }
 

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtilsSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtilsSuite.scala
@@ -99,7 +99,8 @@ class KubernetesClientUtilsSuite extends SparkFunSuite with BeforeAndAfter {
           .withLabels(properties.asJava)
         .endMetadata()
         .withImmutable(true)
-        .addToData(confFileMap.asJava)
+        .addToData(confFileMap.collect{case (key, (value, true)) => key -> value}.asJava)
+        .addToBinaryData(confFileMap.collect{case (key, (value, false)) => key -> value}.asJava)
         .build()
     assert(outputConfigMap === expectedConfigMap)
   }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtilsSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtilsSuite.scala
@@ -30,6 +30,7 @@ import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.k8s.Config
+import org.apache.spark.deploy.k8s.submit.ConfigMapItem
 import org.apache.spark.util.Utils
 
 class KubernetesClientUtilsSuite extends SparkFunSuite with BeforeAndAfter {
@@ -57,9 +58,9 @@ class KubernetesClientUtilsSuite extends SparkFunSuite with BeforeAndAfter {
       Map("binary-file.conf" -> data)
     val sparkConf = testSetup(input)
     val output = KubernetesClientUtils.loadSparkConfDirFiles(sparkConf)
-    val expectedOutput = Map("test.txt" -> ("test123", true),
-      "sample.conf" -> ("conf", true), "_test" -> ("", true),
-      "binary-file.conf" -> (Base64.encodeBase64String(data), false))
+    val expectedOutput = Map("test.txt" -> ConfigMapItem("test123", true),
+      "sample.conf" -> ConfigMapItem("conf", true), "_test" -> ConfigMapItem("", true),
+      "binary-file.conf" -> ConfigMapItem(Base64.encodeBase64String(data), false))
     assert(output === expectedOutput)
   }
 
@@ -68,12 +69,12 @@ class KubernetesClientUtilsSuite extends SparkFunSuite with BeforeAndAfter {
     val sparkConf = testSetup(input.map(f => f._1 -> f._2.getBytes(StandardCharsets.UTF_8)))
       .set(Config.CONFIG_MAP_MAXSIZE.key, "60")
     val output = KubernetesClientUtils.loadSparkConfDirFiles(sparkConf)
-    val expectedOutput = Map("testConf.1" -> ("test123456", true),
-      "testConf.2" -> ("test123456", true))
+    val expectedOutput = Map("testConf.1" -> ConfigMapItem("test123456", true),
+      "testConf.2" -> ConfigMapItem("test123456", true))
     assert(output === expectedOutput)
     val output1 = KubernetesClientUtils.loadSparkConfDirFiles(
       sparkConf.set(Config.CONFIG_MAP_MAXSIZE.key, "250000"))
-    assert(output1 === input.map(a => a._1 -> (a._2, true)))
+    assert(output1 === input.map(a => a._1 -> ConfigMapItem(a._2, true)))
   }
 
   test("verify load files, truncates the content to maxSize, when keys are equal in length.") {
@@ -81,9 +82,9 @@ class KubernetesClientUtilsSuite extends SparkFunSuite with BeforeAndAfter {
     val sparkConf = testSetup(input.map(f => f._1 -> f._2.getBytes(StandardCharsets.UTF_8)))
       .set(Config.CONFIG_MAP_MAXSIZE.key, "80")
     val output = KubernetesClientUtils.loadSparkConfDirFiles(sparkConf)
-    val expectedOutput = Map("testConf.1" -> ("test123456", true),
-      "testConf.2" -> ("test123456", true),
-      "testConf.3" -> ("test123456", true))
+    val expectedOutput = Map("testConf.1" -> ConfigMapItem("test123456", true),
+      "testConf.2" -> ConfigMapItem("test123456", true),
+      "testConf.3" -> ConfigMapItem("test123456", true))
     assert(output === expectedOutput)
   }
 
@@ -105,8 +106,12 @@ class KubernetesClientUtilsSuite extends SparkFunSuite with BeforeAndAfter {
           .withLabels(properties.asJava)
         .endMetadata()
         .withImmutable(true)
-        .addToData(confFileMap.collect{case (key, (value, true)) => key -> value}.asJava)
-        .addToBinaryData(confFileMap.collect{case (key, (value, false)) => key -> value}.asJava)
+        .addToData(confFileMap.collect {
+          case (key, ConfigMapItem(value, true)) => key -> value
+        }.asJava)
+        .addToBinaryData(confFileMap.collect {
+          case (key, ConfigMapItem(value, false)) => key -> value
+        }.asJava)
         .build()
     assert(outputConfigMap === expectedConfigMap)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Spark on k8s cannot pass binary files to driver/executors as it uses `data` field of `ConfigMap`. Let's use `binaryData` as well to share binary files.


### Why are the changes needed?

To share `jceks` files for Ranger ssl to work.


### How was this patch tested?

Manually deploy to k8s


### Was this patch authored or co-authored using generative AI tooling?

No
