### PR TITLE
NGSOK-1401 Backport SPARK-48392 (--load-spark-defaults) into spark 3.5.4

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -50,6 +50,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
   var executorCores: String = null
   var totalExecutorCores: String = null
   var propertiesFile: String = null
+  private var loadSparkDefaults: Boolean = false
   var driverMemory: String = null
   var driverExtraClassPath: String = null
   var driverExtraLibraryPath: String = null
@@ -86,27 +87,6 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
   var submissionToRequestStatusFor: String = null
   var useRest: Boolean = false // used internally
 
-  /** Default properties present in the currently defined defaults file. */
-  lazy val defaultSparkProperties: HashMap[String, String] = {
-    val defaultProperties = new HashMap[String, String]()
-    if (verbose) {
-      logInfo(s"Using properties file: $propertiesFile")
-    }
-    Option(propertiesFile).foreach { filename =>
-      val properties = Utils.getPropertiesFromFile(filename)
-      properties.foreach { case (k, v) =>
-        defaultProperties(k) = v
-      }
-      // Property files may contain sensitive information, so redact before printing
-      if (verbose) {
-        Utils.redact(properties).foreach { case (k, v) =>
-          logInfo(s"Adding default property: $k=$v")
-        }
-      }
-    }
-    defaultProperties
-  }
-
   // Set parameters from command line arguments
   parse(args.asJava)
 
@@ -122,21 +102,43 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
   validateArguments()
 
   /**
+   * Load properties from the file with the given path into `sparkProperties`.
+   * No-op if the file path is null
+   */
+  private def loadPropertiesFromFile(filePath: String): Unit = {
+    if (filePath != null) {
+      if (verbose) {
+        logInfo(log"Using properties file: ${MDC(PATH, filePath)}")
+      }
+      val properties = Utils.getPropertiesFromFile(filePath)
+      properties.foreach { case (k, v) =>
+        if (!sparkProperties.contains(k)) {
+          sparkProperties(k) = v
+        }
+      }
+      // Property files may contain sensitive information, so redact before printing
+      if (verbose) {
+        Utils.redact(properties).foreach { case (k, v) =>
+          logInfo(log"Adding default property: ${MDC(KEY, k)}=${MDC(VALUE, v)}")
+        }
+      }
+    }
+  }
+
+  /**
    * Merge values from the default properties file with those specified through --conf.
    * When this is called, `sparkProperties` is already filled with configs from the latter.
    */
   private def mergeDefaultSparkProperties(): Unit = {
-    // Use common defaults file, if not specified by user
-    propertiesFile = Option(propertiesFile).getOrElse(Utils.getDefaultPropertiesFile(env))
-    // Honor --conf before the defaults file
-    // Filter sparkProperties to exclude blacklisted properties using default options
-    val filteredProp = Utils.filterBlacklistedProperties(defaultSparkProperties, sparkProperties)
+    // Honor --conf before the specified properties file and defaults file
+    loadPropertiesFromFile(propertiesFile)
 
-    // Merge filtered default properties into sparkProperties
-    defaultSparkProperties.foreach { case (k, v) =>
-      if (!filteredProp.contains(k)) {
-        sparkProperties(k) = v
-      }
+    // Also load properties from `spark-defaults.conf` if they do not exist in the properties file
+    // and --conf list when:
+    //   - no input properties file is specified
+    //   - input properties file is specified, but `--load-spark-defaults` flag is set
+    if (propertiesFile == null || loadSparkDefaults) {
+      loadPropertiesFromFile(Utils.getDefaultPropertiesFile(env))
     }
   }
 
@@ -394,6 +396,9 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
       case PROPERTIES_FILE =>
         propertiesFile = value
 
+      case LOAD_SPARK_DEFAULTS =>
+        loadSparkDefaults = true
+
       case KILL_SUBMISSION =>
         submissionToKill = value
         if (action != null) {
@@ -537,6 +542,10 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
         |  --conf, -c PROP=VALUE       Arbitrary Spark configuration property.
         |  --properties-file FILE      Path to a file from which to load extra properties. If not
         |                              specified, this will look for conf/spark-defaults.conf.
+        |  --load-spark-defaults       Whether to load properties from conf/spark-defaults.conf,
+        |                              even if --properties-file is specified. Configurations
+        |                              specified in --properties-file will take precedence over
+        |                              those in conf/spark-defaults.conf.
         |
         |  --driver-memory MEM         Memory for driver (e.g. 1000M, 2G) (Default: ${mem_mb}M).
         |  --driver-java-options       Extra Java options to pass to the driver.

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -111,8 +111,13 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
         logInfo(log"Using properties file: ${MDC(PATH, filePath)}")
       }
       val properties = Utils.getPropertiesFromFile(filePath)
+
+      // Filter sparkProperties to exclude blacklisted properties using default options
+      val filteredProp = Utils.filterBlacklistedProperties(properties, sparkProperties)
+
+      // Merge filtered default properties into sparkProperties
       properties.foreach { case (k, v) =>
-        if (!sparkProperties.contains(k)) {
+        if (!sparkProperties.contains(k) && !filteredProp.contains(k)) {
           sparkProperties(k) = v
         }
       }

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -108,7 +108,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
   private def loadPropertiesFromFile(filePath: String): Unit = {
     if (filePath != null) {
       if (verbose) {
-        logInfo(log"Using properties file: ${MDC(PATH, filePath)}")
+        logInfo(s"Using properties file: $propertiesFile")
       }
       val properties = Utils.getPropertiesFromFile(filePath)
 
@@ -124,7 +124,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
       // Property files may contain sensitive information, so redact before printing
       if (verbose) {
         Utils.redact(properties).foreach { case (k, v) =>
-          logInfo(log"Adding default property: ${MDC(KEY, k)}=${MDC(VALUE, v)}")
+          logInfo(s"Adding default property: $k=$v")
         }
       }
     }

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -105,29 +105,22 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
    * Load properties from the file with the given path into `sparkProperties`.
    * No-op if the file path is null
    */
-  private def loadPropertiesFromFile(filePath: String): Unit = {
+  private def loadPropertiesFromFile(filePath: String): collection.Map[String, String] = {
     if (filePath != null) {
       if (verbose) {
         logInfo(s"Using properties file: $propertiesFile")
       }
       val properties = Utils.getPropertiesFromFile(filePath)
 
-      // Filter sparkProperties to exclude blacklisted properties using default options
-      val filteredProp = Utils.filterBlacklistedProperties(properties, sparkProperties)
-
-      // Merge filtered default properties into sparkProperties
-      properties.foreach { case (k, v) =>
-        if (!sparkProperties.contains(k) && !filteredProp.contains(k)) {
-          sparkProperties(k) = v
-        }
-      }
       // Property files may contain sensitive information, so redact before printing
       if (verbose) {
         Utils.redact(properties).foreach { case (k, v) =>
           logInfo(s"Adding default property: $k=$v")
         }
       }
+      return properties
     }
+    Map.empty
   }
 
   /**
@@ -136,14 +129,46 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
    */
   private def mergeDefaultSparkProperties(): Unit = {
     // Honor --conf before the specified properties file and defaults file
-    loadPropertiesFromFile(propertiesFile)
+    val properties = loadPropertiesFromFile(propertiesFile)
+
+    mergeProperties(properties)
+
+    val defaultProperties = loadPropertiesFromFile(Utils.getDefaultPropertiesFile(env))
+
+    // Filter sparkProperties to exclude blacklisted properties using default options
+    removeSparkBlacklistedProperties(defaultProperties)
 
     // Also load properties from `spark-defaults.conf` if they do not exist in the properties file
     // and --conf list when:
     //   - no input properties file is specified
     //   - input properties file is specified, but `--load-spark-defaults` flag is set
     if (propertiesFile == null || loadSparkDefaults) {
-      loadPropertiesFromFile(Utils.getDefaultPropertiesFile(env))
+      mergeProperties(defaultProperties)
+    }
+  }
+
+  /**
+   * Merge properties
+   */
+  private def mergeProperties(properties: collection.Map[String, String]): Unit = {
+    properties.foreach { case (k, v) =>
+      if (!sparkProperties.contains(k)) {
+        sparkProperties(k) = v
+      }
+    }
+  }
+
+  /**
+   * Remove properties that are in black list
+   */
+  private def removeSparkBlacklistedProperties(
+                                                defaultProperties: collection.Map[String, String]
+                                              ): Unit = {
+    val filteredProp = Utils.filterBlacklistedProperties(defaultProperties, sparkProperties)
+    sparkProperties.keys.foreach { k =>
+      if (!filteredProp.contains(k)) {
+        sparkProperties -= k
+      }
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -1056,9 +1056,46 @@ class SparkSubmitSuite
         "--master", "local",
         unusedJar.toString)
       val appArgs = new SparkSubmitArguments(args, env = Map("SPARK_CONF_DIR" -> path))
-      assert(appArgs.propertiesFile != null)
-      assert(appArgs.propertiesFile.startsWith(path))
       appArgs.executorMemory should be ("3g")
+    }
+  }
+
+  test("SPARK-48392: load spark-defaults.conf when --load-spark-defaults is set") {
+    forConfDir(Map("spark.executor.memory" -> "3g", "spark.driver.memory" -> "3g")) { path =>
+      withPropertyFile("spark-conf.properties",
+        Map("spark.executor.cores" -> "16", "spark.driver.memory" -> "4g")) { propsFile =>
+        val unusedJar = TestUtils.createJarWithClasses(Seq.empty)
+        val args = Seq(
+          "--class", SimpleApplicationTest.getClass.getName.stripSuffix("$"),
+          "--name", "testApp",
+          "--master", "local",
+          "--properties-file", propsFile,
+          "--load-spark-defaults",
+          unusedJar.toString)
+        val appArgs = new SparkSubmitArguments(args, env = Map("SPARK_CONF_DIR" -> path))
+        appArgs.executorCores should be("16")
+        appArgs.executorMemory should be("3g")
+        appArgs.driverMemory should be("4g")
+      }
+    }
+  }
+
+  test("SPARK-48392: should skip spark-defaults.conf when --load-spark-defaults is not set") {
+    forConfDir(Map("spark.executor.memory" -> "3g", "spark.driver.memory" -> "3g")) { path =>
+      withPropertyFile("spark-conf.properties",
+        Map("spark.executor.cores" -> "16", "spark.driver.memory" -> "4g")) { propsFile =>
+        val unusedJar = TestUtils.createJarWithClasses(Seq.empty)
+        val args = Seq(
+          "--class", SimpleApplicationTest.getClass.getName.stripSuffix("$"),
+          "--name", "testApp",
+          "--master", "local",
+          "--properties-file", propsFile,
+          unusedJar.toString)
+        val appArgs = new SparkSubmitArguments(args, env = Map("SPARK_CONF_DIR" -> path))
+        appArgs.executorCores should be("16")
+        appArgs.driverMemory should be("4g")
+        appArgs.executorMemory should be(null)
+      }
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -1099,6 +1099,105 @@ class SparkSubmitSuite
     }
   }
 
+  test("SPARK-48392: blacklist should applies to properties-file when " +
+    "--load-spark-defaults is set") {
+    forConfDir(Map("spark.sql.extensions" -> "bar",
+      "spark.sql.security.confblacklist" -> "spark.sql.extensions")) { path =>
+      withPropertyFile("spark-conf.properties",
+        Map("spark.sql.extensions" -> "baz")) { propsFile =>
+        val unusedJar = TestUtils.createJarWithClasses(Seq.empty)
+        val args = Seq(
+          "--class", SimpleApplicationTest.getClass.getName.stripSuffix("$"),
+          "--name", "testApp",
+          "--master", "local",
+          "--properties-file", propsFile,
+          "--load-spark-defaults",
+          unusedJar.toString)
+        val appArgs = new SparkSubmitArguments(args, env = Map("SPARK_CONF_DIR" -> path))
+        appArgs.sparkProperties("spark.sql.extensions") should be("bar")
+      }
+    }
+  }
+
+  test("SPARK-48392: blacklist should applies to properties-file when " +
+    "--load-spark-defaults is not set") {
+    forConfDir(Map("spark.sql.extensions" -> "bar",
+      "spark.sql.security.confblacklist" -> "spark.sql.extensions")) { path =>
+      withPropertyFile("spark-conf.properties",
+        Map("spark.sql.extensions" -> "baz")) { propsFile =>
+        val unusedJar = TestUtils.createJarWithClasses(Seq.empty)
+        val args = Seq(
+          "--class", SimpleApplicationTest.getClass.getName.stripSuffix("$"),
+          "--name", "testApp",
+          "--master", "local",
+          "--properties-file", propsFile,
+          unusedJar.toString)
+        val appArgs = new SparkSubmitArguments(args, env = Map("SPARK_CONF_DIR" -> path))
+        assert(!appArgs.sparkProperties.contains("spark.sql.extensions"))
+      }
+    }
+  }
+
+  test("SPARK-48392: --properties-file should not override blacklist from spark-defaults.conf " +
+    "when --load-spark-defaults is set") {
+    forConfDir(Map(
+      "spark.sql.security.confblacklist" -> "spark.sql.extensions")) { path =>
+      withPropertyFile("spark-conf.properties",
+        Map("spark.sql.security.confblacklist" -> "bar",
+          "spark.sql.extensions" -> "baz")) { propsFile =>
+        val unusedJar = TestUtils.createJarWithClasses(Seq.empty)
+        val args = Seq(
+          "--class", SimpleApplicationTest.getClass.getName.stripSuffix("$"),
+          "--name", "testApp",
+          "--master", "local",
+          "--properties-file", propsFile,
+          "--load-spark-defaults",
+          unusedJar.toString)
+        val appArgs = new SparkSubmitArguments(args, env = Map("SPARK_CONF_DIR" -> path))
+        appArgs.sparkProperties("spark.sql.security.confblacklist"
+          ) should be("spark.sql.extensions")
+        assert(!appArgs.sparkProperties.contains("spark.sql.extensions"))
+      }
+    }
+  }
+
+  test("ADH-4803: blacklist should not skip spark-defaults.conf defined options") {
+    forConfDir(Map("spark.sql.security.confblacklist" -> "spark.sql.extensions",
+      "spark.sql.extensions" -> "baz", "spark.driver.memory" -> "4g")) { path =>
+      val unusedJar = TestUtils.createJarWithClasses(Seq.empty)
+      val args = Seq(
+        "--class", SimpleApplicationTest.getClass.getName.stripSuffix("$"),
+        "--name", "testApp",
+        "--master", "local",
+        unusedJar.toString)
+      val appArgs = new SparkSubmitArguments(args, env = Map("SPARK_CONF_DIR" -> path))
+      appArgs.sparkProperties("spark.sql.security.confblacklist"
+      ) should be("spark.sql.extensions")
+      appArgs.sparkProperties("spark.sql.extensions") should be("baz")
+      appArgs.sparkProperties("spark.driver.memory") should be("4g")
+    }
+  }
+
+  test("ADH-4803: blacklist should skip --conf defined options") {
+    forConfDir(Map("spark.sql.security.confblacklist" -> "spark.sql.extensions",
+      "spark.sql.extensions" -> "baz", "spark.driver.memory" -> "4g")) { path =>
+      val unusedJar = TestUtils.createJarWithClasses(Seq.empty)
+      val args = Seq(
+        "--class", SimpleApplicationTest.getClass.getName.stripSuffix("$"),
+        "--name", "testApp",
+        "--master", "local",
+        "--conf", "spark.sql.extensions=bar",
+        "--conf", "spark.executor.cores=16",
+        unusedJar.toString)
+      val appArgs = new SparkSubmitArguments(args, env = Map("SPARK_CONF_DIR" -> path))
+      appArgs.sparkProperties("spark.sql.security.confblacklist"
+      ) should be("spark.sql.extensions")
+      appArgs.sparkProperties("spark.sql.extensions") should be("baz")
+      appArgs.sparkProperties("spark.driver.memory") should be("4g")
+      appArgs.sparkProperties("spark.executor.cores") should be("16")
+    }
+  }
+
   test("support glob path") {
     withTempDir { tmpJarDir =>
       withTempDir { tmpFileDir =>

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -1532,6 +1532,22 @@ class SparkSubmitSuite
     }
   }
 
+  private def withPropertyFile(fileName: String, conf: Map[String, String])(f: String => Unit) = {
+    withTempDir { tmpDir =>
+      val props = new java.util.Properties()
+      val propsFile = File.createTempFile(fileName, "", tmpDir)
+      val propsOutputStream = new FileOutputStream(propsFile)
+      try {
+        conf.foreach { case (k, v) => props.put(k, v) }
+        props.store(propsOutputStream, "")
+      } finally {
+        propsOutputStream.close()
+      }
+
+      f(propsFile.getPath)
+    }
+  }
+
   private def updateConfWithFakeS3Fs(conf: Configuration): Unit = {
     conf.set("fs.s3a.impl", classOf[TestFileSystem].getCanonicalName)
     conf.set("fs.s3a.impl.disable.cache", "true")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,13 +99,18 @@ such as `--master`, as shown above. `spark-submit` can accept any Spark property
 flag, but uses special flags for properties that play a part in launching the Spark application.
 Running `./bin/spark-submit --help` will show the entire list of these options.
 
-`bin/spark-submit` will also read configuration options from `conf/spark-defaults.conf`, in which
-each line consists of a key and a value separated by whitespace. For example:
+When configurations are specified via the `--conf/-c` flags, `bin/spark-submit` will also read
+configuration options from `conf/spark-defaults.conf`, in which each line consists of a key and
+a value separated by whitespace. For example:
 
     spark.master            spark://5.6.7.8:7077
     spark.executor.memory   4g
     spark.eventLog.enabled  true
     spark.serializer        org.apache.spark.serializer.KryoSerializer
+
+In addition, a property file with Spark configurations can be passed to `bin/spark-submit` via
+`--properties-file` parameter. When this is set, Spark will no longer load configurations from
+`conf/spark-defaults.conf` unless another parameter `--load-spark-defaults` is provided.
 
 Any values specified as flags or in the properties file will be passed on to the application
 and merged with those specified through SparkConf. Properties set directly on the SparkConf

--- a/docs/submitting-applications.md
+++ b/docs/submitting-applications.md
@@ -194,9 +194,13 @@ The master URL passed to Spark can be in one of the following formats:
 # Loading Configuration from a File
 
 The `spark-submit` script can load default [Spark configuration values](configuration.html) from a
-properties file and pass them on to your application. By default, it will read options
-from `conf/spark-defaults.conf` in the Spark directory. For more detail, see the section on
-[loading default configurations](configuration.html#loading-default-configurations).
+properties file and pass them on to your application. The file can be specified via the `--properties-file`
+parameter. When this is not specified, by default Spark will read options from `conf/spark-defaults.conf`
+in the `SPARK_HOME` directory.
+
+An additional flag `--load-spark-defaults` can be used to tell Spark to load configurations from `conf/spark-defaults.conf`
+even when a property file is provided via `--properties-file`. This is useful, for instance, when users
+want to put system-wide default settings in the former while user/cluster specific settings in the latter.
 
 Loading default Spark configurations this way can obviate the need for certain flags to
 `spark-submit`. For instance, if the `spark.master` property is set, you can safely omit the

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitOptionParser.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitOptionParser.java
@@ -54,6 +54,7 @@ class SparkSubmitOptionParser {
   protected final String PACKAGES = "--packages";
   protected final String PACKAGES_EXCLUDE = "--exclude-packages";
   protected final String PROPERTIES_FILE = "--properties-file";
+  protected final String LOAD_SPARK_DEFAULTS = "--load-spark-defaults";
   protected final String PROXY_USER = "--proxy-user";
   protected final String PY_FILES = "--py-files";
   protected final String REPOSITORIES = "--repositories";
@@ -128,6 +129,7 @@ class SparkSubmitOptionParser {
     { USAGE_ERROR },
     { VERBOSE, "-v" },
     { VERSION },
+    { LOAD_SPARK_DEFAULTS },
   };
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

Backport SPARK-48392 (`--load-spark-defaults`) into spark 3.5.4.

### Why are the changes needed?
To allow store user-provided options in file and merge them with defaults.


### Does this PR introduce _any_ user-facing change?

Adds `--load-spark-defaults` option.

```
In addition, a property file with Spark configurations can be passed to `bin/spark-submit` via
`--properties-file` parameter. When this is set, Spark will no longer load configurations from
`conf/spark-defaults.conf` unless another parameter `--load-spark-defaults` is provided.
```


### How was this patch tested?

Using unit tests.


### Was this patch authored or co-authored using generative AI tooling?

No.
