### PR TITLE
NGSOK-1479 Implement (optional) time-based rolling for logs

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileWriters.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileWriters.scala
@@ -20,6 +20,7 @@ package org.apache.spark.deploy.history
 import java.io._
 import java.net.URI
 import java.nio.charset.StandardCharsets
+import java.time.{Duration, Instant}
 
 import org.apache.commons.io.output.CountingOutputStream
 import org.apache.hadoop.conf.Configuration
@@ -298,6 +299,10 @@ class RollingEventLogFilesWriter(
 
   private val eventFileMaxLength = sparkConf.get(EVENT_LOG_ROLLING_MAX_FILE_SIZE)
 
+  private val eventRollingInterval = sparkConf.get(EVENT_LOG_ROLLING_INTERVAL)
+
+  private var lastRollingTime: Instant = Instant.now()
+
   private val logDirForAppPath = getAppEventLogDirPath(logBaseDir, appId, appAttemptId)
 
   private var countingOutputStream: Option[CountingOutputStream] = None
@@ -328,6 +333,16 @@ class RollingEventLogFilesWriter(
       val currentLen = countingOutputStream.get.getByteCount
       if (currentLen + eventJson.length > eventFileMaxLength) {
         rollEventLogFile()
+      } else {
+        // if eventRollingInterval set
+        eventRollingInterval match {
+          case Some(eventRollingIntervalValue) =>
+            val elapsed = Duration.between(lastRollingTime, Instant.now())
+            if (elapsed.compareTo(Duration.ofSeconds(eventRollingIntervalValue)) >= 0) {
+              rollEventLogFile()
+            }
+          case None => true
+        }
       }
     }
 
@@ -347,6 +362,9 @@ class RollingEventLogFilesWriter(
       new PrintWriter(
         new OutputStreamWriter(countingOutputStream.get, StandardCharsets.UTF_8))
     }
+
+    // to not re-roll if rolled
+    lastRollingTime = Instant.now()
   }
 
   override def stop(): Unit = {

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -313,6 +313,13 @@ package object config {
         "configured to be at least 10 MiB.")
       .createWithDefaultString("128m")
 
+  private[spark] val EVENT_LOG_ROLLING_INTERVAL =
+    ConfigBuilder("spark.eventLog.rolling.interval")
+      .doc("Force rolling if the previous rolling was more than interval in past.")
+      .version("3.5.4")
+      .timeConf(TimeUnit.SECONDS)
+      .createOptional
+
   private[spark] val EXECUTOR_ID =
     ConfigBuilder("spark.executor.id").version("1.2.0").stringConf.createOptional
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1485,6 +1485,14 @@ Apart from these, the following properties are also available, and may be useful
   <td>3.0.0</td>
 </tr>
 <tr>
+  <td><code>spark.eventLog.rolling.interval</code></td>
+  <td>None</td>
+  <td>
+    Force rolling if the previous rolling was more than interval in past.
+  </td>
+  <td>3.5.4</td>
+</tr>
+<tr>
   <td><code>spark.ui.dagGraph.retainedRootRDDs</code></td>
   <td>Int.MaxValue</td>
   <td>


### PR DESCRIPTION
In order to see an information inside in-progress tab of SparkHistoryServer based on Ozone/S3a we are forced to wait for full block filled (lower limit is 10MB). Let's implement time-based rolling (e.g. if event come after N seconds after last rolling, roll).
