### PR TITLE
NGSOK-1458 Allow to use k8s master without url

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -3283,7 +3283,7 @@ private object SparkMasterRegex {
   // Regular expression for connecting to Spark deploy clusters
   val SPARK_REGEX = """spark://(.*)""".r
   // Regular expression for connecting to kubernetes clusters
-  val KUBERNETES_REGEX = """k8s://(.*)""".r
+  val KUBERNETES_REGEX = """k8s(?:://(.*))?""".r
 }
 
 /**

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -543,7 +543,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
       s"""
         |Options:
         |  --master MASTER_URL         spark://host:port, mesos://host:port, yarn,
-        |                              k8s://https://host:port, or local (Default: local[*]).
+        |                              k8s://https://host:port, k8s, or local (Default: local[*]).
         |  --deploy-mode DEPLOY_MODE   Whether to launch the driver program locally ("client") or
         |                              on one of the worker machines inside the cluster ("cluster")
         |                              (Default: client).

--- a/core/src/main/scala/org/apache/spark/resource/ResourceProfileManager.scala
+++ b/core/src/main/scala/org/apache/spark/resource/ResourceProfileManager.scala
@@ -53,7 +53,7 @@ private[spark] class ResourceProfileManager(sparkConf: SparkConf,
   private val dynamicEnabled = Utils.isDynamicAllocationEnabled(sparkConf)
   private val master = sparkConf.getOption("spark.master")
   private val isYarn = master.isDefined && master.get.equals("yarn")
-  private val isK8s = master.isDefined && master.get.startsWith("k8s://")
+  private val isK8s = master.isDefined && master.get.startsWith("k8s")
   private val isStandaloneOrLocalCluster = master.isDefined && (
       master.get.startsWith("spark://") || master.get.startsWith("local-cluster")
     )

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2833,13 +2833,16 @@ private[spark] object Utils
   }
 
   /**
-   * Check the validity of the given Kubernetes master URL and return the resolved URL. Prefix
-   * "k8s://" is appended to the resolved URL as the prefix is used by KubernetesClusterManager
-   * in canCreate to determine if the KubernetesClusterManager should be used.
+   * Check the validity of the given Kubernetes master URL and return the resolved URL.
+   * The URL must start with "k8s://" (to resolve master URL) or be exactly
+   * "k8s" (to use the default master).
    */
   def checkAndGetK8sMasterUrl(rawMasterURL: String): String = {
-    require(rawMasterURL.startsWith("k8s://"),
-      "Kubernetes master URL must start with k8s://.")
+    require(rawMasterURL.startsWith("k8s://") || rawMasterURL == "k8s",
+      "Kubernetes master URL must start with k8s:// or be exactly k8s.")
+    if (rawMasterURL == "k8s") {
+      return rawMasterURL
+    }
     val masterWithoutK8sPrefix = rawMasterURL.substring("k8s://".length)
 
     // To handle master URLs, e.g., k8s://host:port.

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -1317,6 +1317,9 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
     val k8sMasterURLWithoutScheme2 = Utils.checkAndGetK8sMasterUrl("k8s://127.0.0.1")
     assert(k8sMasterURLWithoutScheme2 === "k8s://https://127.0.0.1")
 
+    val k8sMasterURLWithoutAddress = Utils.checkAndGetK8sMasterUrl("k8s")
+    assert(k8sMasterURLWithoutAddress === "k8s")
+
     intercept[IllegalArgumentException] {
       Utils.checkAndGetK8sMasterUrl("k8s:https://host:port")
     }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
@@ -140,7 +140,12 @@ object KubernetesUtils extends Logging {
   }
 
   @Since("2.4.0")
-  def parseMasterUrl(url: String): String = url.substring("k8s://".length)
+  def parseMasterUrl(url: String): String = {
+    if (url.startsWith("k8s://")) {
+      return url.substring("k8s://".length)
+    }
+    "k8s"
+  }
 
   @Since("3.0.0")
   def formatPairsBundle(pairs: Seq[(String, String)], indent: Int = 1) : String = {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
@@ -88,7 +88,9 @@ private[spark] object SparkKubernetesClientFactory extends Logging {
     // explicit setting pass null
     val config = new ConfigBuilder(autoConfigure(kubeContext.orNull))
       .withApiVersion("v1")
-      .withMasterUrl(master)
+      .withOption(Option(master).filter(_ != "k8s")) { (url, configBuilder) =>
+        configBuilder.withMasterUrl(url)
+      }
       .withRequestTimeout(clientType.requestTimeout(sparkConf))
       .withConnectionTimeout(clientType.connectionTimeout(sparkConf))
       .withTrustCerts(sparkConf.get(KUBERNETES_TRUST_CERTIFICATES))

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/BasicTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/BasicTestsSuite.scala
@@ -90,6 +90,12 @@ private[spark] trait BasicTestsSuite { k8sSuite: KubernetesSuite =>
     runSparkPiAndVerifyCompletion()
   }
 
+  test("Run SparkPi with a master k8s without a URL.", k8sTestTag) {
+    val k8sMasterUrl = s"k8s"
+    sparkAppConf.set("spark.master", k8sMasterUrl)
+    runSparkPiAndVerifyCompletion()
+  }
+
   test("Run SparkPi with an argument.", k8sTestTag) {
     // This additional configuration with snappy is for SPARK-26995
     sparkAppConf


### PR DESCRIPTION
### What changes were proposed in this pull request?

Allow to use k8s master without url (e.g. `--master=k8s`).


### Why are the changes needed?


To simplify user interaction


### How was this patch tested?

Tests added
